### PR TITLE
ui: add Javadocs in PersonDetailsPanel to satisfy Checkstyle

### DIFF
--- a/src/main/java/seedu/address/ui/PersonDetailsPanel.java
+++ b/src/main/java/seedu/address/ui/PersonDetailsPanel.java
@@ -64,10 +64,10 @@ public class PersonDetailsPanel extends UiPart<Region> {
     }
 
     /**
-     * Populates the details panel with the fields of the given {@code person}.
-     * If {@code person} is {@code null}, the panel shows an empty state.
+     * Updates the panel to display details of the given person.
      *
      * @param person the selected person whose details should be shown; may be {@code null}
+     *               to clear the panel when no person is selected
      */
     public void setPerson(Person person) {
         if (person == null) {


### PR DESCRIPTION
WHAT
- Add minimal Javadocs to the public constructor and setPerson(...) in
  PersonDetailsPanel.

WHY
- Resolves MissingJavadocMethod warnings and keeps the UI code within the
  course's Checkstyle rules.
- Improves reader clarity without changing behavior.

Notes
- No production logic changes.
- ./gradlew clean check passes locally.