### PR TITLE
schema-based CSV and --profile support

### DIFF
--- a/src/main/java/seedu/address/logic/export/ColumnSpec.java
+++ b/src/main/java/seedu/address/logic/export/ColumnSpec.java
@@ -1,0 +1,24 @@
+package seedu.address.logic.export;
+
+import java.util.function.Function;
+
+/**
+ * Describes a single CSV column: its header text and how to extract
+ * the string value from a domain object (e.g., PersonReadOnly).
+ *
+ * Keep this class dumb and generic — it lets the export command stay
+ * unaware of concrete fields and future columns.
+ */
+public final class ColumnSpec<T> {
+    public final String header;
+    public final Function<T, String> extractor;
+
+    private ColumnSpec(String header, Function<T, String> extractor) {
+        this.header = header;
+        this.extractor = extractor;
+    }
+
+    public static <T> ColumnSpec<T> of(String header, Function<T, String> extractor) {
+        return new ColumnSpec<>(header, extractor);
+    }
+}

--- a/src/main/java/seedu/address/logic/export/ExportSchemas.java
+++ b/src/main/java/seedu/address/logic/export/ExportSchemas.java
@@ -1,0 +1,41 @@
+package seedu.address.logic.export;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import seedu.address.model.person.PersonReadOnly;
+
+/**
+ * Preset, extensible column schemas for CSV export.
+ * Add/remove columns here without touching command code.
+ */
+public final class ExportSchemas {
+    private ExportSchemas() {}
+
+    /** Current behaviour: 5 columns. */
+    public static List<ColumnSpec<PersonReadOnly>> standard() {
+        return List.of(
+                ColumnSpec.of("Name",    p -> p.getName().toString()),
+                ColumnSpec.of("Phone",   p -> p.getPhone().toString()),
+                ColumnSpec.of("Email",   p -> p.getEmail().toString()),
+                ColumnSpec.of("Address", p -> p.getAddress().toString()),
+                ColumnSpec.of("Tags",    p -> p.getTags().stream()
+                        .map(Object::toString).collect(Collectors.joining(";")))
+        );
+    }
+
+    /** Future-ready: adds Role, Cadence, Interactions count. */
+    public static List<ColumnSpec<PersonReadOnly>> full() {
+        return List.of(
+                ColumnSpec.of("Name",    p -> p.getName().toString()),
+                ColumnSpec.of("Phone",   p -> p.getPhone().toString()),
+                ColumnSpec.of("Email",   p -> p.getEmail().toString()),
+                ColumnSpec.of("Address", p -> p.getAddress().toString()),
+                ColumnSpec.of("Tags",    p -> p.getTags().stream()
+                        .map(Object::toString).collect(Collectors.joining(";"))),
+                ColumnSpec.of("Role",        p -> p.getRole() == null ? "" : p.getRole().toString()),
+                ColumnSpec.of("Cadence",     p -> p.getCadence().map(Object::toString).orElse("")),
+                ColumnSpec.of("Interactions",p -> Integer.toString(p.getInteractions().size()))
+        );
+    }
+}

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -17,7 +17,7 @@ import seedu.address.model.tag.Tag;
  * Represents a Person in the address book.
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
-public class Person {
+public class Person implements PersonReadOnly{
 
     // Identity fields
     private final Name name;

--- a/src/main/java/seedu/address/model/person/PersonReadOnly.java
+++ b/src/main/java/seedu/address/model/person/PersonReadOnly.java
@@ -1,0 +1,19 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import seedu.address.model.interaction.Interaction;
+import seedu.address.model.tag.Tag;
+
+public interface PersonReadOnly {
+    Name getName();
+    Phone getPhone();
+    Email getEmail();
+    Address getAddress();
+    Set<Tag> getTags();
+    Role getRole();
+    Optional<Cadence> getCadence();
+    List<Interaction> getInteractions();
+}

--- a/src/main/java/seedu/address/model/util/CsvUtil.java
+++ b/src/main/java/seedu/address/model/util/CsvUtil.java
@@ -22,15 +22,22 @@ import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
 
 /**
- * Utility class for reading {@link Person} objects from a CSV file.
+ * CSV utilities for the address book domain.
  * <p>
- * This class provides a single method, {@link #readPersonsFromCsv(Path)},
- * which parses a comma-separated file containing person information.
- * Each non-empty line should be in the following format:
- * <pre>
- * Name, Phone, Email, [Address], [Tags separated by ';']
- * </pre>
- * Fields in brackets are optional. Malformed lines are skipped gracefully.
+ * <b>Export:</b> Provides {@link #writeHeader(List, java.io.Writer)},
+ * {@link #writeRow(List, java.io.Writer)}, and {@link #escape(String)} to write
+ * CSV safely. Fields containing commas, quotes, or newlines are escaped by
+ * doubling quotes and wrapping the cell in quotes.
+ * <p>
+ * <b>Import:</b> Provides {@link #readPersonsFromCsv(Path)} which parses a
+ * simplified CSV containing people in the order:
+ * <pre>Name, Phone, Email, [Address], [Tags separated by ';']</pre>
+ * Address and tags are optional. Malformed lines are skipped.
+ * <p><strong>Note:</strong> The current importer is a simple splitter and does
+ * not honor quoted fields. If a field contains commas or newlines, it must be
+ * fixed in a future iteration with a proper CSV parser.
+ * <p>
+ * This class is stateless and thread-safe.
  */
 public class CsvUtil {
 
@@ -38,6 +45,8 @@ public class CsvUtil {
 
     private static final int MIN_FIELDS = 3; // Name, Phone, Email
     private static final int MAX_FIELDS = 5; // Includes optional Address and Tags
+    private static final char DELIM = ',';
+    private static final String NEWLINE = "\n";
 
     /**
      * Reads a list of {@link Person} objects from a CSV file.
@@ -121,5 +130,50 @@ public class CsvUtil {
         }
 
         return new Person(name, phone, email, address, tags);
+    }
+
+    /**
+     * Escapes a string for CSV output.
+     * <ul>
+     *   <li>Doubles any double quotes ({@code " -> ""}).</li>
+     *   <li>If the cell contains the delimiter, a quote, or a newline, wraps the
+     *       entire cell in double quotes.</li>
+     *   <li>Null values are rendered as empty strings.</li>
+     * </ul>
+     *
+     * @param s the cell value, possibly {@code null}
+     * @return an export-safe CSV cell
+     */
+    public static String escape(String s) {
+        if (s == null) return "";
+        boolean needsQuotes = s.indexOf(DELIM) >= 0 || s.indexOf('"') >= 0
+                || s.indexOf('\n') >= 0 || s.indexOf('\r') >= 0;
+        String v = s.replace("\"", "\"\"");
+        return needsQuotes ? "\"" + v + "\"" : v;
+    }
+
+    /**
+     * Writes a header row to the writer using the current delimiter.
+     * Calls {@link #writeRow(List, java.io.Writer)} under the hood.
+     *
+     * @param headers ordered list of column names (nulls rendered empty)
+     * @param out the writer to append to
+     * @throws IOException if writing fails
+     */
+
+    public static void writeHeader(List<String> headers, java.io.Writer out) throws IOException {
+        writeRow(headers, out);
+    }
+
+    public static void writeRow(List<String> cells, java.io.Writer out) throws IOException {
+        // Null-safe and escape each cell
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < cells.size(); i++) {
+            String cell = cells.get(i);
+            sb.append(escape(cell == null ? "" : cell));
+            if (i + 1 < cells.size()) sb.append(DELIM);
+        }
+        sb.append(NEWLINE);
+        out.write(sb.toString());
     }
 }


### PR DESCRIPTION
* Use ColumnSpec + ExportSchemas to define CSV columns.
* Add --profile {standard|full} to choose export schema.
* Keep default STANDARD: Name, Phone, Email, Address, Tags.
* FULL adds Role, Cadence, Interactions count.
* Show selected profile in success message.
* Prevent overwrite by adding numeric suffixes.
* Improve logging and JavaDocs for export flow.

parser: validate --profile and clean filename
* Accept flag anywhere in args (regex based).
* Error on missing, unknown, or duplicate profile flags.
* Reject leftover flag-like filenames (start with "--").
* Preserve simple filename parsing otherwise.

model: add PersonReadOnly and implement in Person
* Provide read-only getters for export decoupling.

csvutil: clarify docs and keep safe writers
* Escape quotes, commas, and newlines correctly.
* Note: importer uses simple split for now.

tests: update for profile and add FULL case
* Expect profile text in success message.
* Add test writing with FULL schema.